### PR TITLE
Option to preserve stats from segment diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,9 @@ target/
 # PyCharm
 .idea
 
-
 .~lock*
+
+#osx
+.DS_Store
+
+debug/

--- a/tests/test_match_stats.py
+++ b/tests/test_match_stats.py
@@ -1,0 +1,18 @@
+import itertools
+
+from gpsdio_segment.core import SegmentState
+from gpsdio_segment.core import Segment
+from gpsdio_segment.core import Segmentizer
+import gpsdio
+
+
+
+def test_Segmentizer_collect_match_stats(tmpdir):
+    outfile = str(tmpdir.mkdir('test_Segmentizer_collect_match_stats').join('segmented.json'))
+
+    with gpsdio.open('tests/data/416000000.json') as src:
+        segmentizer = Segmentizer(src, collect_match_stats=True)
+
+        for seg in segmentizer:
+            for msg in seg:
+                assert 'segment_matches' in msg


### PR DESCRIPTION
Closes #47 

New option `collect_match_stats` for Segmentizer that captures all the stats used to determine which segment a message is added to.  The stats are added to the message in a field called `segment_matches`

