### PR TITLE
Improve performance when all messages are non-pos

### DIFF
--- a/gpsdio_segment/core.py
+++ b/gpsdio_segment/core.py
@@ -368,8 +368,8 @@ class Segmentizer(object):
 
             _yielded = []
             for segment in self._segments.values():
-                if timestamp and segment.last_msg.get('timestamp'):
-                    last_msg = segment.last_time_posit_msg or segment.last_msg
+                last_msg = segment.last_time_posit_msg or segment.last_msg
+                if timestamp and last_msg:
                     td = self.timedelta(msg, last_msg)
                     if td > self.max_hours:
                         if False:
@@ -425,7 +425,6 @@ class Segmentizer(object):
             else:
                 try:
                     best_match, noise_factor = self._compute_best(msg)
-                    assert noise_factor is not None
                 except ValueError as e:
                     if False:
                         logger.debug("    Out of bound points, could not compute best segment: %s", e)

--- a/gpsdio_segment/segment.py
+++ b/gpsdio_segment/segment.py
@@ -33,6 +33,7 @@ class Segment(object):
 
         self._prev_state = None
         self._prev_segment = None
+        self._last_time_posit_msg = None
 
         self._msgs = []
         self._coords = []
@@ -103,7 +104,7 @@ class Segment(object):
         prev_msg = None
         for msg in [self.first_msg,
                     self.last_time_posit_msg,
-                    self.last_posit_msg,
+                    # self.last_posit_msg,
                     self.last_msg]:
             if msg is not None and msg is not prev_msg:
                 state.msgs.append(msg)
@@ -160,33 +161,16 @@ class Segment(object):
             return self._prev_segment.last_msg if self._prev_segment else None
 
     @property
-    def last_posit_msg(self):
-        """
-        Return the last message added to the segment with lat and lon values
-        that are not `None`.
-        """
-
-        for msg in reversed(self.msgs):
-            if msg.get('lat') is not None \
-                    and msg.get('lon') is not None:
-                return msg
-
-        return self._prev_segment.last_posit_msg if self._prev_segment else None
-
-    @property
     def last_time_posit_msg(self):
         """
         Return the last message added to the segment with `lat`, `lon`, and
         `timestamp` fields that are not `None`.
         """
 
-        for msg in reversed(self.msgs):
-            if msg.get('lat') is not None \
-                    and msg.get('lon') is not None \
-                    and msg.get('timestamp') is not None:
-                return msg
-
-        return self._prev_segment.last_time_posit_msg if self._prev_segment else None
+        if self._last_time_posit_msg:
+            return self._last_time_posit_msg
+        else:
+            return self._prev_segment.last_time_posit_msg if self._prev_segment else None
 
     @property
     def first_msg (self):
@@ -236,6 +220,8 @@ class Segment(object):
         self._msgs.append(msg)
         if msg.get('lat') is not None and msg.get('lon') is not None:
             self._coords.append((msg['lon'], msg['lat']))
+            if msg.get('timestamp') is not None:
+                self._last_time_posit_msg = msg
 
 
 class BadSegment(Segment):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -112,17 +112,14 @@ def test_last_msg_combinations():
 
     seg.add_msg(non_posit)
     assert seg.last_msg == non_posit
-    assert seg.last_posit_msg is None
     assert seg.last_time_posit_msg is None
 
     seg.add_msg(posit)
     assert seg.last_msg == posit
-    assert seg.last_posit_msg == posit
     assert seg.last_time_posit_msg is None
 
     seg.add_msg(time_posit)
     assert seg.last_msg == time_posit
-    assert seg.last_posit_msg == time_posit
     assert seg.last_time_posit_msg == time_posit
 
     # Make sure posit and posit time are being returned instead of just the last message
@@ -131,17 +128,14 @@ def test_last_msg_combinations():
     seg.add_msg(posit)
     seg.add_msg(non_posit)
     assert seg.last_msg == non_posit
-    assert seg.last_posit_msg == posit
     assert seg.last_time_posit_msg is None
 
     seg.add_msg(time_posit)
     seg.add_msg(non_posit)
     assert seg.last_msg == non_posit
-    assert seg.last_posit_msg == time_posit
     assert seg.last_time_posit_msg == time_posit
 
     seg.add_msg(time_posit)
     seg.add_msg(non_posit)
     assert seg.last_msg == non_posit
-    assert seg.last_posit_msg == time_posit
     assert seg.last_time_posit_msg == time_posit

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -41,25 +41,21 @@ def test_Segment_state_save_load(msg_generator):
     assert seg2._prev_state
 
     assert seg2.last_msg == seg1.last_msg
-    assert seg2.last_posit_msg == seg1.last_posit_msg
     assert seg2.last_time_posit_msg == seg1.last_time_posit_msg
 
     msg = msg_generator.next_msg()
     seg2.add_msg(msg)
     assert seg2.last_msg == msg
-    assert seg2.last_posit_msg == seg1.last_posit_msg
     assert seg2.last_time_posit_msg == seg1.last_time_posit_msg
 
     msg = msg_generator.next_posit_msg()
     seg2.add_msg(msg)
     assert seg2.last_msg == msg
-    assert seg2.last_posit_msg == msg
     assert seg2.last_time_posit_msg == seg1.last_time_posit_msg
 
     msg = msg_generator.next_time_posit_msg()
     seg2.add_msg(msg)
     assert seg2.last_msg == msg
-    assert seg2.last_posit_msg == msg
     assert seg2.last_time_posit_msg == msg
 
     msg = msg_generator.next_msg()


### PR DESCRIPTION
Fix #55

**8.31s improved to 0.07s for 10k messages**

Before:
```
Positional messages only: 10000
123456789-2017-01-01T00:00:00.000000Z 10000
time: 0.433874845505
Identity messages only: 10000
123456789-2017-01-01T00:00:00.000000Z 10000
time: 8.31052112579
```
After:
```
Positional messages only: 10000
123456789-2017-01-01T00:00:00.000000Z 10000
time: 0.313764810562
Identity messages only: 10000
123456789-2017-01-01T00:00:00.000000Z 10000
time: 0.0716710090637
```

