### PR TITLE
Duplicate timestamp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,19 +1,25 @@
-Changelog
-=========
+# Changelog
 
-DEV
--------------------
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### ADDED
 * [#61](https://github.com/SkyTruth/gpsdio-segment/issues/61)
   Prefer segments with matching shipname and/or callsign
+* [#63](https://github.com/SkyTruth/gpsdio-segment/issues/63)
+  Treat a duplicate timestamp that is within noise distance from an existing segment as noise
 
-0.12
--------------------
+## 0.12
 * [#60](https://github.com/SkyTruth/gpsdio-segment/pull/60) 
   Prefer segments with the same message type
 
 
-0.11 - (2017-12-31)
--------------------
+## 0.11 - (2017-12-31)
 
 * ['#54'](https://github.com/SkyTruth/gpsdio-segment/pull/54)
   Ignore noise segments in Segmentizer.from_seg_states()
@@ -22,8 +28,7 @@ DEV
   Performance improvement for the special case where all messages added to a segment are 
   non-positional (have no lat/lon as is the case with type 5 AIS messages)
 
-0.10 - (2017-12-22)
--------------------
+## 0.10 - (2017-12-22)
 
 * ['#50'](https://github.com/SkyTruth/gpsdio-segment/pull/50)
   Emit noise messages in a new segment class `NoiseSegment` that works like 
@@ -35,56 +40,47 @@ DEV
   a field called `segment_matches`
 
   
-0.9 - (2017-10-18)
-------------------
+## 0.9 - (2017-10-18)
 
 - New parameters that reduce the allowable speed at distance and handle noise better #42
 
 
-0.8 - (2017-08-22)
-------------------
+## 0.8 - (2017-08-22)
 
 - Documentation and reorganization
 
 
-0.7 - (2017-01-26)
-------------------
+## 0.7 - (2017-01-26)
 
 - Bugfix for no reported speed.
 
 
-0.6 - (2016-08-30)
-------------------
+## 0.6 - (2016-08-30)
 
 - Improved segmenting algorithm to handle high speed better .  #32, #34
 
 
-0.5 - (2016-06-10)
-------------------
+## 0.5 - (2016-06-10)
 
 - Better handling bad locations to prevent subsequent positions from being added to `BadSegment()`.  #29
 
 
-0.4 - (2016-05-23)
-------------------
+## 0.4 - (2016-05-23)
 
 - Handle an edge case where a non-posit is the first message encountered after clearing out _all_ segments.  #24
 
 
-0.3 - (2016-05-17)
-------------------
+## 0.3 - (2016-05-17)
 
 - Better handling for out-of-bounds locations.  #17
 - Shush logging.  #19
 
 
-0.2 - (2015-10-06)
-------------------
+## 0.2 - (2015-10-06)
 
 - Added states for Segmentizer and Segments.  #13
 
 
-0.1 - (2015-06-24)
-------------------
+## 0.1 - (2015-06-24)
 
 - Initial release.


### PR DESCRIPTION
Closes #63 

Treat a duplicate timestamp that is within noise distance from an existing segment as noise
