### PR TITLE
More duplicate timestamps

### DIFF
--- a/gpsdio_segment/core.py
+++ b/gpsdio_segment/core.py
@@ -338,6 +338,9 @@ class Segmentizer(object):
             elif match['distance'] < self.noise_dist:
                 # kick this out as noise
                 match['noise_factor'] = 2.0
+            else:
+                # Allow this to match another existing segment, but do not create a new segment
+                match['noise_factor'] = 1.0
         else:
             # allow a higher max computed speed for vessels that report a high speed
             max_speed_at_inf = max(self.max_speed, match['reported_speed'] * self.reported_speed_multiplier)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -233,3 +233,12 @@ def test_duplicate_ts_multiple_segs():
     segments = list(Segmentizer(messages))
     # idx=4 comes out first because it is emitted as a noise segment
     assert [{4}, {0, 2, 3},{1}] == [{msg['idx'] for msg in seg} for seg in segments]
+
+def test_duplicate_ts_noise_dist_zero():
+    messages = [
+        {'idx': 0, 'mmsi': 1, 'lat': 0, 'lon': 0, 'timestamp': datetime(2018, 1, 1, 1, 0, 0)},
+        {'idx': 1, 'mmsi': 1, 'lat': 0.01, 'lon': 0.01, 'timestamp': datetime(2018, 1, 1, 1, 0, 0)},
+    ]
+
+    segments = list(Segmentizer(messages, noise_dist=0))
+    assert [({1}, True), ({0}, False)] == [({msg['idx'] for msg in seg}, seg.noise) for seg in segments]


### PR DESCRIPTION
Slight modification to duplicate timestamp handling to address #63 

This was needed because of the realization that in production we are setting noise_distance=0 so all the logic that uses that parameter has no effect.   

Connects https://github.com/GlobalFishingWatch/pipe-segment/issues/89
Connects https://github.com/GlobalFishingWatch/pipe-segment/issues/90
