### PR TITLE
When no shipname or callsign matches, prefer the segment with the most recent position

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* [#66](https://github.com/SkyTruth/gpsdio-segment/issues/66)
+  When no shipname or callsign matches, prefer the segment with the most recent position
 
 ### ADDED
 * [#61](https://github.com/SkyTruth/gpsdio-segment/issues/61)

--- a/gpsdio_segment/core.py
+++ b/gpsdio_segment/core.py
@@ -328,8 +328,10 @@ class Segmentizer(object):
 
         if match['timedelta'] > self.max_hours:
             match['metric'] = None
-        elif match['distance'] == 0 or match['distance'] is None:
+        elif match['distance'] == 0:
             match['metric'] = match['timedelta'] / seg_duration
+        elif match['distance'] is None:
+            match['metric'] = match['timedelta']
         elif match['timedelta'] == 0:
             # only keep identical timestamps if the distance is small
             # allow for the distance you can go at max speed for one minute

--- a/gpsdio_segment/core.py
+++ b/gpsdio_segment/core.py
@@ -261,7 +261,7 @@ class Segmentizer(object):
 
         type1 = self.message_type(msg1)
         type2 = self.message_type(msg2)
-        type_match = None if type1 is None or type2 is None else type1 == type2
+        type_mismatch = None if type1 is None or type2 is None else type1 != type2
         timedelta = self.timedelta(msg1, msg2)
         reported_speed = max(self.reported_speed(msg1), self.reported_speed(msg2))
 
@@ -291,7 +291,7 @@ class Segmentizer(object):
             'reported_speed': reported_speed,
             # 'noise_factor': self.noise_dist / distance if distance is not None and distance > 0 else 0,
             'noise_factor': 1.0 if distance < self.noise_dist else 0.0,
-            'type_match': type_match
+            'type_mismatch': type_mismatch
         }
 
 
@@ -388,7 +388,7 @@ class Segmentizer(object):
             matches = [m for m in matches if m['metric'] is not None]
 
             # try limiting to just segments with the same message type, if there are any
-            type_matches = [m for m in matches if m['type_match']] or matches
+            type_matches = [m for m in matches if not m['type_mismatch']] or matches
 
             # try limiting to just segments with matching shipname, if there are any
             shipname_matches = [m for m in type_matches if m.get('shipname_match')] or type_matches

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,20 +5,23 @@ import datetime
 class MessageGenerator(object):
     def __init__(self, mmsi=None):
         self.mmsi = mmsi if mmsi else 123456789
+        self.reset()
+
+    def reset(self):
         self.timestamp = datetime.datetime.now()
         self.lat = 0
         self.lon = 0
-        self.field = 0
+        self.index = 0
 
     def increment(self):
-        self.timestamp += datetime.timedelta(minutes=1)
+        self.timestamp += datetime.timedelta(hours=1)
         self.lat += 0.01
         self.lon += 0.01
-        self.field += 1
+        self.index += 1
 
     def next_msg(self):
         self.increment()
-        return {'mmsi': self.mmsi, 'field': self.field}
+        return {'mmsi': self.mmsi, 'idx': self.index}
 
     def next_posit_msg(self):
         self.increment()
@@ -28,6 +31,26 @@ class MessageGenerator(object):
         self.increment()
         return {
             'mmsi': self.mmsi, 'lat': self.lat, 'lon': self.lon, 'timestamp': self.timestamp}
+
+    def next_msg_from_stub(self, stub):
+        self.increment()
+        msg = dict(
+            idx=self.index,
+            mmsi=self.mmsi,
+            timestamp=self.timestamp
+        )
+        msg.update(stub)
+        seg = msg.get('seg', 0)
+        if msg.get('type', 99) in (1, 3, 18, 19):
+            msg['lat'] = self.lat + (seg * 2)
+            msg['lon'] = self.lon + (seg * 2)
+
+        return msg
+
+    def generate_messages (self, message_stubs):
+        self.reset()
+        for stub in message_stubs:
+            yield self.next_msg_from_stub(stub)
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_ident_message.py
+++ b/tests/test_ident_message.py
@@ -96,6 +96,16 @@ def generate_messages(message_stubs):
       {'seg': 0, 'type': 24, 'callsign': '1'},  # goes to seg 0 because it matches
       {'seg': 1, 'type': 24, 'callsign': '2'}]  # goes to seg 1 because that is the most recent position
     ),
+    ([{'seg': 0, 'type': 18},
+      {'seg': 0, 'type': 18},
+      {'seg': 0, 'type': 18},
+      {'seg': 0, 'type': 18},
+      {'seg': 0, 'type': 18},
+      {'seg': 0, 'type': 18},
+      {'seg': 1, 'type': 18},
+      {'seg': 1, 'type': 24, 'shipname': 'A'}, # no specific match, so it goes to the segment with the most recent position
+      ]
+    ),
 ])
 def test_seg_ident(message_stubs):
     messages = list(generate_messages(message_stubs))
@@ -116,4 +126,3 @@ def test_seg_ident(message_stubs):
         assert actual == expected
 
     # assert False
-

--- a/tests/test_ident_message.py
+++ b/tests/test_ident_message.py
@@ -83,7 +83,7 @@ from gpsdio_segment.core import Segmentizer
     ),
 ])
 def test_seg_ident(message_stubs, msg_generator):
-    messages = list(msg_generator.generate_messages(messae_stubs))
+    messages = list(msg_generator.generate_messages(message_stubs))
     segments = list(Segmentizer(messages))
 
     # group the input messages into exected segment groups based on the 'seg' field

--- a/tests/test_ident_message.py
+++ b/tests/test_ident_message.py
@@ -13,31 +13,6 @@ from gpsdio_segment.core import Segmentizer
 
 
 
-def generate_messages(message_stubs):
-    t = datetime.now()
-    lat = 0
-    lon = 0
-
-    for idx, stub in enumerate(message_stubs):
-        msg = dict(
-            idx=idx,
-            mmsi=1,
-            timestamp = t
-        )
-        msg.update(stub)
-
-        if msg.get('type', 99) in (1, 18, 19):
-            msg['lat'] = lat + (msg['seg'] * 2)
-            msg['lon'] = lon + (msg['seg'] * 2)
-
-        t += timedelta(hours=1)
-        lat += 0.01
-        lon += 0.01
-
-        yield msg
-
-
-
 @pytest.mark.parametrize("message_stubs", [
     ( [{'seg': 0, 'type': 1},                   # one segement, one name
        {'seg': 0, 'type': 5, 'shipname': 'A'}]
@@ -107,8 +82,8 @@ def generate_messages(message_stubs):
       ]
     ),
 ])
-def test_seg_ident(message_stubs):
-    messages = list(generate_messages(message_stubs))
+def test_seg_ident(message_stubs, msg_generator):
+    messages = list(msg_generator.generate_messages(messae_stubs))
     segments = list(Segmentizer(messages))
 
     # group the input messages into exected segment groups based on the 'seg' field

--- a/tests/test_message_type.py
+++ b/tests/test_message_type.py
@@ -6,6 +6,7 @@ import pytest
 
 from datetime import datetime
 from datetime import timedelta
+from itertools import groupby
 
 from click.testing import CliRunner
 
@@ -24,8 +25,8 @@ def test_message_type(type, expected):
     assert segmenter.message_type({'type': type}) == expected
 
 @pytest.mark.parametrize("type1,type2,expected", [
-    (1,1,True),
-    (1,18,False),
+    (1,1,False),
+    (1,18,True),
     (1,99,None),
 ])
 def test_one_seg_message_type(type1, type2, expected):
@@ -33,7 +34,7 @@ def test_one_seg_message_type(type1, type2, expected):
     p1 = {'mmsi': 1, 'type': type1, 'lat': 0, 'lon': 0, 'timestamp': datetime.now()}
     p2 = {'mmsi': 1, 'type': type2, 'lat': 0, 'lon': 0, 'timestamp': p1['timestamp'] + timedelta(hours=1)}
     segmenter = Segmentizer([p1, p2])
-    assert segmenter.msg_diff_stats(p1, p2)['type_match'] == expected
+    assert segmenter.msg_diff_stats(p1, p2)['type_mismatch'] == expected
     # Should produce one segment
     assert len(list(segmenter)) == 1
 
@@ -94,3 +95,17 @@ def test_ident_msg_5():
     # Should produce two segments, with ident message 5 grouped with messages 2 and 4
     segments = list(Segmentizer(points))
     assert {tuple(msg['id'] for msg in seg) for seg in segments} == {(2, 4),(1, 3,5)}
+
+
+@pytest.mark.parametrize("label,message_stubs", [
+    (   'class_none',     # test matching when the latest position message does not have a defined class
+        [{'seg': 0, 'type': 1, 'lat': 0.0, 'lon': 0},
+        {'seg': 1, 'type': 1, 'lat': 2.0, 'lon': 0},
+        {'seg': 0, 'type': 1, 'lat': 0.5, 'lon': 0},
+        {'seg': 1, 'type': 3, 'lat': 1.5, 'lon': 0},
+        {'seg': 1, 'type': 1, 'lat': 1.5, 'lon': 0},
+    ]),
+])
+def test_class_none(label, message_stubs, msg_generator):
+
+    msg_generator.assert_segments(message_stubs, label='test_class_none')


### PR DESCRIPTION
Closes #66 
Closes #68 

For #66 When no shipname or callsign matches, prefer the segment with the most recent position.
For #68 Change the type matching from a positive match to a negative non-match.  Provisionally reject a segment match if the type is a mis-match, but allow matching for other combinations