### PR TITLE
Fix class A/B segmentation

### DIFF
--- a/gpsdio_segment/core.py
+++ b/gpsdio_segment/core.py
@@ -369,10 +369,13 @@ class Segmentizer(object):
             # If metric is none, then the segment is not a match candidate
             matches = [m for m in matches if m['metric'] is not None]
 
-            if (msg.get('lat'), msg.get('lon')) == (None, None):
-                # This is not a positional message, so try to limit to 
-                # just segments with the same transmitter type, if there are any
-                matches = [m for m in matches if not m['type_mismatch']] or matches
+            # This seems like a good idea, but some of the tagblocks (receivers)
+            # mess up the message type, so commenting out for now.
+
+            # if (msg.get('lat'), msg.get('lon')) == (None, None):
+            #     # This is not a positional message, so try to limit to 
+            #     # just segments with the same transmitter type, if there are any
+            #     matches = [m for m in matches if not m['type_mismatch']] or matches
 
             metrics = list((match['metric'], match) for match in matches)
 

--- a/gpsdio_segment/core.py
+++ b/gpsdio_segment/core.py
@@ -79,6 +79,7 @@ REPORTED_SPEED_EXCLUSION_RANGES = [(51.0, 51.3),(102.2,103.0)]
 AIS_CLASS = {
     1: 'A',
     2: 'A',
+    3: 'A',
     5: 'A',
     18: 'B',
     19: 'B',
@@ -294,21 +295,6 @@ class Segmentizer(object):
             'type_mismatch': type_mismatch
         }
 
-
-    def msg_shipname_match(self, msg1, msg2):
-        shipname1 = msg1.get('shipname')
-        shipname2 = msg2.get('shipname') if msg2 is not None else None
-        return dict(
-            shipname_match=shipname1 is not None and shipname1 == shipname2
-        )
-
-    def msg_callsign_match(self, msg1, msg2):
-        callsign1 = msg1.get('callsign')
-        callsign2 = msg2.get('callsign') if msg2 is not None else None
-        return dict(
-            callsign_match=callsign1 is not None and callsign1 == callsign2
-        )
-
     def _segment_match(self, segment, msg):
         match = {'seg_id': segment.id,
                  'noise_factor': 0.0,
@@ -319,10 +305,6 @@ class Segmentizer(object):
             return match
 
         match.update(self.msg_diff_stats(msg, segment.last_time_posit_msg))
-
-        if match['distance'] is None:
-            match.update(self.msg_shipname_match(msg, segment.best_shipname_msg))
-            match.update(self.msg_callsign_match(msg, segment.best_callsign_msg))
 
         seg_duration = max(1.0, segment.total_seconds / 3600)
 
@@ -387,16 +369,12 @@ class Segmentizer(object):
             # If metric is none, then the segment is not a match candidate
             matches = [m for m in matches if m['metric'] is not None]
 
-            # try limiting to just segments with the same message type, if there are any
-            type_matches = [m for m in matches if not m['type_mismatch']] or matches
+            if (msg.get('lat'), msg.get('lon')) == (None, None):
+                # This is not a positional message, so try to limit to 
+                # just segments with the same message type, if there are any
+                matches = [m for m in matches if not m['type_mismatch']] or matches
 
-            # try limiting to just segments with matching shipname, if there are any
-            shipname_matches = [m for m in type_matches if m.get('shipname_match')] or type_matches
-
-            # try limiting to just segments with matching callsign, if there are any
-            callsign_matches = [m for m in shipname_matches if m.get('callsign_match')] or shipname_matches
-
-            metrics  = list((match['metric'], match) for match in callsign_matches)
+            metrics = list((match['metric'], match) for match in matches)
 
             if metrics:
                 # find the smallest metric value

--- a/gpsdio_segment/core.py
+++ b/gpsdio_segment/core.py
@@ -371,7 +371,7 @@ class Segmentizer(object):
 
             if (msg.get('lat'), msg.get('lon')) == (None, None):
                 # This is not a positional message, so try to limit to 
-                # just segments with the same message type, if there are any
+                # just segments with the same transmitter type, if there are any
                 matches = [m for m in matches if not m['type_mismatch']] or matches
 
             metrics = list((match['metric'], match) for match in matches)

--- a/tests/test_ident_message.py
+++ b/tests/test_ident_message.py
@@ -14,11 +14,11 @@ from gpsdio_segment.core import Segmentizer
 
 
 @pytest.mark.parametrize("message_stubs", [
-    ( [{'seg': 0, 'type': 1},                   # one segement, one name
+    ( [{'seg': 0, 'type': 1},                   # one segment, one name
        {'seg': 0, 'type': 5, 'shipname': 'A'}]
     ),
     ([{'seg': 0, 'type': 1},                    # only one position, so only one segment, so both names go to the
-      {'seg': 0, 'type': 5, 'shipname': 'A'},   # sane segment
+      {'seg': 0, 'type': 5, 'shipname': 'A'},   # same segment
       {'seg': 0, 'type': 5, 'shipname': 'B'}]
      ),
     ([{'seg': 0, 'type': 1},                    # seg 0 starts
@@ -30,46 +30,42 @@ from gpsdio_segment.core import Segmentizer
       {'seg': 0, 'type': 5, 'shipname': 'A'},   # seg 0 gets name A
       {'seg': 1, 'type': 1},                    # seg 1 starts
       {'seg': 1, 'type': 5, 'shipname': 'B'},   # seg 1 gets name B
-      {'seg': 0, 'type': 5, 'shipname': 'A'}]   # name A goes to seg 0 because the name matches, even though seg 1
-     ),                                         # has the more recent postion
-
+      {'seg': 1, 'type': 5, 'shipname': 'A'}]   # name A also goes to seg 1 because its more recent position
+    ),                                          
     ([{'seg': 0, 'type': 18},                   # seg 0 starts
       {'seg': 0, 'type': 24, 'shipname': 'A'},  # seg 0 gets name A
       {'seg': 1, 'type': 18},                   # seg 1 starts
-      {'seg': 1, 'type': 24, 'shipname': 'B'},  # seg 1 gets name B
-      {'seg': 0, 'type': 24, 'shipname': 'A'},  # name A goes to seg 1 because the name matches
-      {'seg': 1, 'type': 24, 'shipname': 'B'},  # name B goes to seg 2
-      {'seg': 1, 'type': 24, 'shipname': 'C'}]  # name C does not match either seg, so it goes to seg 1 because it has
-    ),                                          # the most recent position
-
+      {'seg': 1, 'type': 24, 'shipname': 'B'},  # seg 1 gets a bunch of names
+      {'seg': 1, 'type': 24, 'shipname': 'A'},  # 
+      {'seg': 1, 'type': 24, 'shipname': 'B'},  # 
+      {'seg': 1, 'type': 24, 'shipname': 'C'}]  # 
+    ),                                          
     ([{'seg': 0, 'type': 18},                   # seg 0 starts
       {'seg': 0, 'type': 24, 'shipname': 'A'},  # seg 0 name is now A
       {'seg': 1, 'type': 18},                   # seg 1 starts
       {'seg': 1, 'type': 24, 'shipname': 'B'},  # seg 1 name is now B
       {'seg': 1, 'type': 24, 'shipname': 'C'},  # seg 1 name changes to C, because seg 1 has the most recent position
-      {'seg': 0, 'type': 24, 'shipname': 'A'},  # seg 0 is still A
+      {'seg': 1, 'type': 24, 'shipname': 'A'},  # seg 1 is now A
       {'seg': 0, 'type': 18},                   # seg 0 now has the most recent positon
-      {'seg': 1, 'type': 24, 'shipname': 'C'},  # seg 1 is still C, even though seg 0 has the most recent position
-      {'seg': 0, 'type': 24, 'shipname': 'B'}]  # seg 0 name changes to B because it does not match A or C and
-                                                # seg 0 has the most recent position
+      {'seg': 0, 'type': 24, 'shipname': 'C'},  # seg 0 is now C
+      {'seg': 0, 'type': 24, 'shipname': 'B'}]  # seg 0 name changes to B
     ),
     ([{'seg': 0, 'type': 19, 'shipname': 'A'},  # seg 0 starts, with name A
       {'seg': 1, 'type': 18},                   # seg 1 starts
       {'seg': 1, 'type': 24, 'shipname': 'B'},  # seg 1 name is now B
       {'seg': 1, 'type': 24, 'shipname': 'C'},  # seg 1 name changes to C, because seg 1 has the most recent position
-      {'seg': 0, 'type': 24, 'shipname': 'A'},  # seg 0 is still A
+      {'seg': 1, 'type': 24, 'shipname': 'A'},  # seg 1 is now A
       {'seg': 0, 'type': 18},                   # seg 0 now has the most recent positon
-      {'seg': 1, 'type': 24, 'shipname': 'C'},  # seg 1 is still C, even though seg 0 has the most recent position
-      {'seg': 0, 'type': 24, 'shipname': 'B'},  # name B goes to seg 0 since it does not match A or C and seg 0 has
-                                                # the most recent position, but the name A is anchored by the type 19 msg
+      {'seg': 0, 'type': 24, 'shipname': 'C'},  # seg 0 is now C
+      {'seg': 0, 'type': 24, 'shipname': 'B'},  # name B goes to seg 0
       {'seg': 1, 'type': 18},                   # seg 1 now has the most recent positon
-      {'seg': 1, 'type': 24, 'shipname': 'B'}]  # this time B goes to seg 1, because seg 0 still has name A
+      {'seg': 1, 'type': 24, 'shipname': 'B'}]  # this time B goes to seg 1
     ),
     ([{'seg': 0, 'type': 19, 'shipname': 'A', 'callsign': '1'},  # seg 0 starts, with name A, callsign 1
       {'seg': 1, 'type': 18},                   # seg 1 starts
       {'seg': 1, 'type': 24, 'shipname': 'B'},  # seg 1 name is now B
-      {'seg': 0, 'type': 24, 'callsign': '1'},  # goes to seg 0 because it matches
-      {'seg': 1, 'type': 24, 'callsign': '2'}]  # goes to seg 1 because that is the most recent position
+      {'seg': 1, 'type': 24, 'callsign': '1'},  # goes to seg 1 
+      {'seg': 1, 'type': 24, 'callsign': '2'}]  # goes to seg 1 
     ),
     ([{'seg': 0, 'type': 18},
       {'seg': 0, 'type': 18},
@@ -78,12 +74,26 @@ from gpsdio_segment.core import Segmentizer
       {'seg': 0, 'type': 18},
       {'seg': 0, 'type': 18},
       {'seg': 1, 'type': 18},
-      {'seg': 1, 'type': 24, 'shipname': 'A'}, # no specific match, so it goes to the segment with the most recent position
+      {'seg': 1, 'type': 24, 'shipname': 'A'}, 
       ]
     ),
+      ([{'seg': 0, 'type': 18},
+        {'seg': 1, 'type': 1},
+        {'seg': 0, 'type': 24, 'callsign' : 'A'}, # Goes to 0 because Tx type matches
+        {'seg': 0, 'type': 18},
+        {'seg': 1, 'type': 5, 'callsign' : 'B'}, # Goes to ` because Tx type matches
+      ]
+    ),
+      ([{'seg': 0, 'type': 18},
+        {'seg': 1, 'type': 18}, # Seg 1 has multiple Tx types
+        {'seg': 1, 'type': 1}, 
+        {'seg': 0, 'type': 24, 'callsign' : 'A'}, # Goes to 1 because MOST recent Tx type for segment matches
+      ]                                           # NOTE: this is not ideal behavior, ideally it goes to 1
+    ),                                            # here, but that's a more complicated fix.
 ])
 def test_seg_ident(message_stubs, msg_generator):
     messages = list(msg_generator.generate_messages(message_stubs))
+    print(messages)
     segments = list(Segmentizer(messages))
 
     # group the input messages into exected segment groups based on the 'seg' field

--- a/tests/test_ident_message.py
+++ b/tests/test_ident_message.py
@@ -77,19 +77,23 @@ from gpsdio_segment.core import Segmentizer
       {'seg': 1, 'type': 24, 'shipname': 'A'}, 
       ]
     ),
-      ([{'seg': 0, 'type': 18},
-        {'seg': 1, 'type': 1},
-        {'seg': 0, 'type': 24, 'callsign' : 'A'}, # Goes to 0 because Tx type matches
-        {'seg': 0, 'type': 18},
-        {'seg': 1, 'type': 5, 'callsign' : 'B'}, # Goes to ` because Tx type matches
-      ]
-    ),
-      ([{'seg': 0, 'type': 18},
-        {'seg': 1, 'type': 18}, # Seg 1 has multiple Tx types
-        {'seg': 1, 'type': 1}, 
-        {'seg': 0, 'type': 24, 'callsign' : 'A'}, # Goes to 1 because MOST recent Tx type for segment matches
-      ]                                           # NOTE: this is not ideal behavior, ideally it goes to 1
-    ),                                            # here, but that's a more complicated fix.
+
+    # These tests are currently not applicable because we have suspended
+    # Tx type matching
+
+    #   ([{'seg': 0, 'type': 18},
+    #     {'seg': 1, 'type': 1},
+    #     {'seg': 0, 'type': 24, 'callsign' : 'A'}, # Goes to 0 because Tx type matches
+    #     {'seg': 0, 'type': 18},
+    #     {'seg': 1, 'type': 5, 'callsign' : 'B'}, # Goes to ` because Tx type matches
+    #   ]
+    # ),
+    #   ([{'seg': 0, 'type': 18},
+    #     {'seg': 1, 'type': 18}, # Seg 1 has multiple Tx types
+    #     {'seg': 1, 'type': 1}, 
+    #     {'seg': 0, 'type': 24, 'callsign' : 'A'}, # Goes to 1 because MOST recent Tx type for segment matches
+    #   ]                                           # NOTE: this is not ideal behavior, ideally it goes to 1
+    # ),                                            # here, but that's a more complicated fix.
 ])
 def test_seg_ident(message_stubs, msg_generator):
     messages = list(msg_generator.generate_messages(message_stubs))

--- a/tests/test_ident_message.py
+++ b/tests/test_ident_message.py
@@ -97,7 +97,6 @@ from gpsdio_segment.core import Segmentizer
 ])
 def test_seg_ident(message_stubs, msg_generator):
     messages = list(msg_generator.generate_messages(message_stubs))
-    print(messages)
     segments = list(Segmentizer(messages))
 
     # group the input messages into exected segment groups based on the 'seg' field

--- a/tests/test_message_type.py
+++ b/tests/test_message_type.py
@@ -54,6 +54,7 @@ def test_two_seg_same_message_type():
     assert {tuple(msg['lat'] for msg in seg) for seg in segments} == {(2.0, 1.5, 1.0),(0.0, 0.5)}
 
 
+@pytest.mark.skip('not doing Tx type matching currently')
 def test_two_seg_diff_message_type():
     # test several points in two segments with the different message types
     # Later messages have no lat/lon so should be treated as identity messages and
@@ -85,6 +86,7 @@ def test_ident_msg_24():
     segments = list(Segmentizer(points))
     assert {tuple(msg['id'] for msg in seg) for seg in segments} == {(2, 4, 5),(1, 3)}
 
+@pytest.mark.skip('not doing Tx type matching currently')
 def test_ident_msg_5():
     # test several points in two segments with the different message types
     t = datetime.now()


### PR DESCRIPTION
See this issue: https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1015

* Remove checks for name/callsign when assigning segments.
* ~Only check for transceiver type when matching info messages.~
* Never check for transceiver type.
* Add type 3 messages to class A message types.